### PR TITLE
fix(usb): hydrate UIO state before enabling controls

### DIFF
--- a/src/api/ble.ts
+++ b/src/api/ble.ts
@@ -3,7 +3,7 @@
 import { BleClient, numberToUUID } from '@capacitor-community/bluetooth-le';
 import { delay } from '../utils';
 import { ApiHandler } from './handler';
-import { createSignalClock, isMobile, dataViewToSignalData, dataViewToMetrics, SignalClock } from './utils';
+import { isMobile, dataViewToSignalData, dataViewToMetrics } from './utils';
 import { ISlotConfig } from '../models/slot';
 const TIO_SVC_UUID = "EECB7DB8-8B2D-402C-B995-825538B49328";
 const TIO_SLOTS_SIG_CHAR_UUIDS = [
@@ -28,14 +28,12 @@ export class BleHandler implements ApiHandler {
   deviceSlots: Record<string, ISlotConfig[]|undefined>;
   callbacks: Record<string, any>;
   deviceSlotStates: Record<string, number[]>;
-  deviceSlotClocks: Record<string, SignalClock[]>;
 
   constructor() {
     this.initialized = false;
     this.deviceSlots = {};
     this.callbacks = {};
     this.deviceSlotStates = {};
-    this.deviceSlotClocks = {};
   }
 
   static async supportedPlatform(): Promise<boolean> {
@@ -110,7 +108,6 @@ export class BleHandler implements ApiHandler {
     await this.deviceDisconnect(deviceId);
     this.deviceSlots[deviceId] = slots;
     this.deviceSlotStates[deviceId] = slots.map(s => 0);
-    this.deviceSlotClocks[deviceId] = slots.map(() => createSignalClock());
     await BleClient.connect(deviceId, onDisconnect);
     await delay(100);
     await BleClient.getServices(deviceId);
@@ -119,7 +116,6 @@ export class BleHandler implements ApiHandler {
   async deviceDisconnect(deviceId: string): Promise<void> {
     this.deviceSlots[deviceId] = undefined;
     this.deviceSlotStates[deviceId] = [];
-    this.deviceSlotClocks[deviceId] = [];
     await BleClient.disconnect(deviceId);
   }
 
@@ -150,7 +146,8 @@ export class BleHandler implements ApiHandler {
           const numChs = slots[slot].chs.length;
           const fs = slots[slot].fs;
           const dtype = slots[slot].dtype;
-          const rst = dataViewToSignalData(data, numChs, fs, dtype, this.deviceSlotClocks[deviceId][slot]);
+          const lastTs = this.deviceSlotStates[deviceId][slot];
+          const rst = dataViewToSignalData(data, numChs, fs, dtype, lastTs);
           await cb(slot, rst.signals, rst.mask);
           this.deviceSlotStates[deviceId][slot] = rst.ts;
         } catch (error) {

--- a/src/api/ble.ts
+++ b/src/api/ble.ts
@@ -3,7 +3,7 @@
 import { BleClient, numberToUUID } from '@capacitor-community/bluetooth-le';
 import { delay } from '../utils';
 import { ApiHandler } from './handler';
-import { isMobile, dataViewToSignalData, dataViewToMetrics } from './utils';
+import { createSignalClock, isMobile, dataViewToSignalData, dataViewToMetrics, SignalClock } from './utils';
 import { ISlotConfig } from '../models/slot';
 const TIO_SVC_UUID = "EECB7DB8-8B2D-402C-B995-825538B49328";
 const TIO_SLOTS_SIG_CHAR_UUIDS = [
@@ -28,12 +28,14 @@ export class BleHandler implements ApiHandler {
   deviceSlots: Record<string, ISlotConfig[]|undefined>;
   callbacks: Record<string, any>;
   deviceSlotStates: Record<string, number[]>;
+  deviceSlotClocks: Record<string, SignalClock[]>;
 
   constructor() {
     this.initialized = false;
     this.deviceSlots = {};
     this.callbacks = {};
     this.deviceSlotStates = {};
+    this.deviceSlotClocks = {};
   }
 
   static async supportedPlatform(): Promise<boolean> {
@@ -108,6 +110,7 @@ export class BleHandler implements ApiHandler {
     await this.deviceDisconnect(deviceId);
     this.deviceSlots[deviceId] = slots;
     this.deviceSlotStates[deviceId] = slots.map(s => 0);
+    this.deviceSlotClocks[deviceId] = slots.map(() => createSignalClock());
     await BleClient.connect(deviceId, onDisconnect);
     await delay(100);
     await BleClient.getServices(deviceId);
@@ -116,6 +119,7 @@ export class BleHandler implements ApiHandler {
   async deviceDisconnect(deviceId: string): Promise<void> {
     this.deviceSlots[deviceId] = undefined;
     this.deviceSlotStates[deviceId] = [];
+    this.deviceSlotClocks[deviceId] = [];
     await BleClient.disconnect(deviceId);
   }
 
@@ -143,11 +147,10 @@ export class BleHandler implements ApiHandler {
       }
       await BleClient.startNotifications(deviceId, TIO_SVC_UUID,  TIO_SLOTS_SIG_CHAR_UUIDS[slot], async (data: DataView) => {
         try {
-          const lastTs = this.deviceSlotStates[deviceId][slot];
           const numChs = slots[slot].chs.length;
           const fs = slots[slot].fs;
           const dtype = slots[slot].dtype;
-          const rst = dataViewToSignalData(data, numChs, fs, dtype, lastTs);
+          const rst = dataViewToSignalData(data, numChs, fs, dtype, this.deviceSlotClocks[deviceId][slot]);
           await cb(slot, rst.signals, rst.mask);
           this.deviceSlotStates[deviceId][slot] = rst.ts;
         } catch (error) {

--- a/src/api/usb.ts
+++ b/src/api/usb.ts
@@ -36,6 +36,13 @@ const TIO_USB_CRC_IDX = 253;
 const TIO_USB_CRC_LEN = 2;
 const TIO_USB_STOP_IDX = 255;
 const TIO_USB_STOP_VAL = 0xAA;
+const TIO_USB_UIO_REQUEST_TIMEOUT_MS = 1000;
+
+interface UioRequest {
+  resolve: (state: number[]) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
 
 // Create device object to store the following:
 // slotConfigs: ISlotConfig[]
@@ -50,6 +57,7 @@ class DeviceState {
   fifo: Uint8Array;
   slotStates: number[];
   interface: number;
+  uioRequest?: UioRequest;
 
   constructor(device: USBDevice) {
     this.device = device;
@@ -187,16 +195,22 @@ export class UsbHandler implements ApiHandler {
       await cb(slotIdx, rst);
 
     } else if (ptype == PacketType.Uio) {
-      const cb = this.callbacks[`dev${deviceId}.uio`];
-      if (cb == undefined) {
-        return null;
-      }
       if (data.length !== 10) {
         console.warn(`Invalid UIO state length: ${data.length}`);
         return null;
       }
       const state = Array.from(data).slice(2, 10);
-      await cb(state);
+      const deviceState = this.deviceStates[deviceId];
+      const request = deviceState.uioRequest;
+      if (request) {
+        clearTimeout(request.timeout);
+        deviceState.uioRequest = undefined;
+        request.resolve(state);
+      }
+      const cb = this.callbacks[`dev${deviceId}.uio`];
+      if (cb !== undefined) {
+        await cb(state);
+      }
 
     }
   }
@@ -377,7 +391,13 @@ export class UsbHandler implements ApiHandler {
     if (!device) {
       return;
     }
-    const ifaceNumber = this.deviceStates[deviceId].interface;
+    const deviceState = this.deviceStates[deviceId];
+    const ifaceNumber = deviceState.interface;
+    if (deviceState.uioRequest) {
+      clearTimeout(deviceState.uioRequest.timeout);
+      deviceState.uioRequest.reject(new Error('USB device disconnected while waiting for UIO state'));
+      deviceState.uioRequest = undefined;
+    }
     this.deviceStates[deviceId].slotConfigs = [];
     this.deviceStates[deviceId].fifo = new Uint8Array([]);
     this.deviceStates[deviceId].slotStates = [];
@@ -439,7 +459,28 @@ export class UsbHandler implements ApiHandler {
   }
 
   async getUioState(deviceId: string): Promise<number[]> {
-    return [];
+    const device = await this._getDevice(deviceId);
+    const deviceState = this.deviceStates[deviceId];
+    if (!device || !deviceState) {
+      throw new Error(`Device ${deviceId} not found`);
+    }
+    if (deviceState.uioRequest) {
+      throw new Error('A UIO state request is already pending');
+    }
+
+    const requestPacket = this.encodePacket(0, PacketType.Uio, []);
+    return await new Promise<number[]>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        deviceState.uioRequest = undefined;
+        reject(new Error('Timed out waiting for UIO state from USB device'));
+      }, TIO_USB_UIO_REQUEST_TIMEOUT_MS);
+      deviceState.uioRequest = { resolve, reject, timeout };
+      device.transferOut(3, requestPacket).catch((error) => {
+        clearTimeout(timeout);
+        deviceState.uioRequest = undefined;
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
   }
 
   async setUioState(deviceId: string, state: number[]): Promise<void> {

--- a/src/api/usb.ts
+++ b/src/api/usb.ts
@@ -1,7 +1,7 @@
 /// <reference types="w3c-web-usb" />
 
 import { ApiHandler } from "./handler";
-import { calculateCRC16, dataViewToSignalData, dataViewToMetrics, isMobile } from './utils';
+import { calculateCRC16, createSignalClock, dataViewToSignalData, dataViewToMetrics, isMobile, SignalClock } from './utils';
 import { ISlotConfig } from "../models/slot";
 import { delay } from "../utils";
 
@@ -9,6 +9,7 @@ enum PacketType {
   Signal = 0,
   Metrics = 1,
   Uio = 2,
+  TimedSignal = 3,
 }
 
   // A packet includes the following fields:
@@ -56,6 +57,7 @@ class DeviceState {
   device: USBDevice;
   fifo: Uint8Array;
   slotStates: number[];
+  slotClocks: SignalClock[];
   interface: number;
   uioRequest?: UioRequest;
 
@@ -64,6 +66,7 @@ class DeviceState {
     this.slotConfigs = [];
     this.fifo = new Uint8Array([]);
     this.slotStates = [];
+    this.slotClocks = [];
     this.interface = 0;
   }
 }
@@ -175,14 +178,14 @@ export class UsbHandler implements ApiHandler {
     const slots = this.deviceStates[deviceId].slotConfigs;
 
     // Handle slot signal
-    if (ptype == PacketType.Signal) {
+    if (ptype == PacketType.Signal || ptype == PacketType.TimedSignal) {
       const cb = this.callbacks[`dev${deviceId}.slot${slotIdx}.sig`];
       if (slots == undefined || slotIdx >= slots.length || cb == undefined) {
         return null;
       }
       const slot = slots[slotIdx];
-      const lastTs = this.deviceStates[deviceId].slotStates[slotIdx];
-      const rst = dataViewToSignalData(new DataView(data.buffer), slot.chs.length, slot.fs, slot.dtype, lastTs);
+      const rst = dataViewToSignalData(new DataView(data.buffer), slot.chs.length, slot.fs, slot.dtype,
+                                       this.deviceStates[deviceId].slotClocks[slotIdx]);
       this.deviceStates[deviceId].slotStates[slotIdx] = rst.ts;
       await cb(slotIdx, rst.signals, rst.mask);
 
@@ -379,6 +382,7 @@ export class UsbHandler implements ApiHandler {
     this.deviceStates[deviceId] = new DeviceState(device);
     this.deviceStates[deviceId].slotConfigs = slots;
     this.deviceStates[deviceId].slotStates = slots.map(s => 0);
+    this.deviceStates[deviceId].slotClocks = slots.map(() => createSignalClock());
 
     await device.open();
 
@@ -401,6 +405,7 @@ export class UsbHandler implements ApiHandler {
     this.deviceStates[deviceId].slotConfigs = [];
     this.deviceStates[deviceId].fifo = new Uint8Array([]);
     this.deviceStates[deviceId].slotStates = [];
+    this.deviceStates[deviceId].slotClocks = [];
 
     await this.disableDevicePolling(deviceId);
 

--- a/src/api/usb.ts
+++ b/src/api/usb.ts
@@ -1,7 +1,7 @@
 /// <reference types="w3c-web-usb" />
 
 import { ApiHandler } from "./handler";
-import { calculateCRC16, createSignalClock, dataViewToSignalData, dataViewToMetrics, isMobile, SignalClock } from './utils';
+import { calculateCRC16, dataViewToSignalData, dataViewToMetrics, isMobile } from './utils';
 import { ISlotConfig } from "../models/slot";
 import { delay } from "../utils";
 
@@ -9,7 +9,6 @@ enum PacketType {
   Signal = 0,
   Metrics = 1,
   Uio = 2,
-  TimedSignal = 3,
 }
 
   // A packet includes the following fields:
@@ -57,7 +56,6 @@ class DeviceState {
   device: USBDevice;
   fifo: Uint8Array;
   slotStates: number[];
-  slotClocks: SignalClock[];
   interface: number;
   uioRequest?: UioRequest;
 
@@ -66,7 +64,6 @@ class DeviceState {
     this.slotConfigs = [];
     this.fifo = new Uint8Array([]);
     this.slotStates = [];
-    this.slotClocks = [];
     this.interface = 0;
   }
 }
@@ -178,14 +175,14 @@ export class UsbHandler implements ApiHandler {
     const slots = this.deviceStates[deviceId].slotConfigs;
 
     // Handle slot signal
-    if (ptype == PacketType.Signal || ptype == PacketType.TimedSignal) {
+    if (ptype == PacketType.Signal) {
       const cb = this.callbacks[`dev${deviceId}.slot${slotIdx}.sig`];
       if (slots == undefined || slotIdx >= slots.length || cb == undefined) {
         return null;
       }
       const slot = slots[slotIdx];
-      const rst = dataViewToSignalData(new DataView(data.buffer), slot.chs.length, slot.fs, slot.dtype,
-                                       this.deviceStates[deviceId].slotClocks[slotIdx]);
+      const lastTs = this.deviceStates[deviceId].slotStates[slotIdx];
+      const rst = dataViewToSignalData(new DataView(data.buffer), slot.chs.length, slot.fs, slot.dtype, lastTs);
       this.deviceStates[deviceId].slotStates[slotIdx] = rst.ts;
       await cb(slotIdx, rst.signals, rst.mask);
 
@@ -382,7 +379,6 @@ export class UsbHandler implements ApiHandler {
     this.deviceStates[deviceId] = new DeviceState(device);
     this.deviceStates[deviceId].slotConfigs = slots;
     this.deviceStates[deviceId].slotStates = slots.map(s => 0);
-    this.deviceStates[deviceId].slotClocks = slots.map(() => createSignalClock());
 
     await device.open();
 
@@ -405,7 +401,6 @@ export class UsbHandler implements ApiHandler {
     this.deviceStates[deviceId].slotConfigs = [];
     this.deviceStates[deviceId].fifo = new Uint8Array([]);
     this.deviceStates[deviceId].slotStates = [];
-    this.deviceStates[deviceId].slotClocks = [];
 
     await this.disableDevicePolling(deviceId);
 

--- a/src/api/usb.ts
+++ b/src/api/usb.ts
@@ -36,7 +36,8 @@ const TIO_USB_CRC_IDX = 253;
 const TIO_USB_CRC_LEN = 2;
 const TIO_USB_STOP_IDX = 255;
 const TIO_USB_STOP_VAL = 0xAA;
-const TIO_USB_UIO_REQUEST_TIMEOUT_MS = 1000;
+const TIO_USB_UIO_REQUEST_TIMEOUT_MS = 1500;
+const TIO_USB_UIO_REQUEST_ATTEMPTS = 3;
 
 interface UioRequest {
   resolve: (state: number[]) => void;
@@ -469,18 +470,29 @@ export class UsbHandler implements ApiHandler {
     }
 
     const requestPacket = this.encodePacket(0, PacketType.Uio, []);
-    return await new Promise<number[]>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        deviceState.uioRequest = undefined;
-        reject(new Error('Timed out waiting for UIO state from USB device'));
-      }, TIO_USB_UIO_REQUEST_TIMEOUT_MS);
-      deviceState.uioRequest = { resolve, reject, timeout };
-      device.transferOut(3, requestPacket).catch((error) => {
-        clearTimeout(timeout);
-        deviceState.uioRequest = undefined;
-        reject(error instanceof Error ? error : new Error(String(error)));
-      });
-    });
+    let lastError: Error|undefined;
+    for (let attempt = 0; attempt < TIO_USB_UIO_REQUEST_ATTEMPTS; attempt++) {
+      try {
+        return await new Promise<number[]>((resolve, reject) => {
+          const timeout = setTimeout(() => {
+            deviceState.uioRequest = undefined;
+            reject(new Error('Timed out waiting for UIO state from USB device'));
+          }, TIO_USB_UIO_REQUEST_TIMEOUT_MS);
+          deviceState.uioRequest = { resolve, reject, timeout };
+          device.transferOut(3, requestPacket).catch((error) => {
+            clearTimeout(timeout);
+            deviceState.uioRequest = undefined;
+            reject(error instanceof Error ? error : new Error(String(error)));
+          });
+        });
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (attempt + 1 < TIO_USB_UIO_REQUEST_ATTEMPTS) {
+          await delay(100);
+        }
+      }
+    }
+    throw lastError || new Error('Failed reading UIO state from USB device');
   }
 
   async setUioState(deviceId: string, state: number[]): Promise<void> {

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -17,86 +17,17 @@ function getDataByteLength(dtype: string): number {
   return 0;
 }
 
-const TIMED_SIGNAL_MAGIC0 = 0x54;
-const TIMED_SIGNAL_MAGIC1 = 0x53;
-const TIMED_SIGNAL_VERSION = 1;
-const TIMED_SIGNAL_HEADER_LEN = 12;
-const STREAM_PLAYOUT_DELAY_MS = 500;
-
-export interface SignalClock {
-  lastTs: number;
-  sourceBaseMs?: number;
-  hostBaseMs?: number;
-  lastSourceDeltaMs?: number;
-  lastSequence?: number;
-}
-
-export function createSignalClock(): SignalClock {
-  return { lastTs: 0 };
-}
-
-export function dataViewToSignalData(data: DataView, numChs: number, fs: number, dtype: string, clock: SignalClock): {signals: number[][], mask: number[][], ts: number} {
+export function dataViewToSignalData(data: DataView, numChs: number, fs: number, dtype: string, lastTs: number): {signals: number[][], mask: number[][], ts: number} {
   const ts = 1000/fs;
   const byteLen = getDataByteLength(dtype);
-  const stride = numChs * byteLen + 2;
-  const packetLen = data.getUint16(0, true);
-  let signalBytes = packetLen;
-  let offset = 2;
-  let sourceMs: number|undefined;
-  let sequence: number|undefined;
-
-  if (packetLen >= TIMED_SIGNAL_HEADER_LEN &&
-      data.byteLength >= 2 + TIMED_SIGNAL_HEADER_LEN &&
-      data.getUint8(2) === TIMED_SIGNAL_MAGIC0 &&
-      data.getUint8(3) === TIMED_SIGNAL_MAGIC1 &&
-      data.getUint8(4) === TIMED_SIGNAL_VERSION) {
-    sourceMs = data.getUint32(6, true);
-    sequence = data.getUint16(10, true);
-    signalBytes = data.getUint16(12, true);
-    offset += TIMED_SIGNAL_HEADER_LEN;
-    if (signalBytes + TIMED_SIGNAL_HEADER_LEN > packetLen) {
-      throw new Error('Timed signal payload length exceeds packet length');
-    }
-  }
-  if (stride === 0 || signalBytes % stride !== 0) {
-    throw new Error('Invalid signal payload length');
-  }
-  const signalLen = signalBytes / stride;
+  const signalLen = data.getUint16(0, true) / (numChs * byteLen + 2);
   const signals: number[][] = [];
   const mask: number[][] = [];
-  if (!signalLen) {
-    return {signals, mask, ts: clock.lastTs};
+  let offset = 2;
+  let refDate = Date.now() - ts*signalLen;
+  if (refDate < lastTs) {
+    refDate = lastTs;
   }
-
-  const now = Date.now();
-  const latestAllowed = now - STREAM_PLAYOUT_DELAY_MS;
-  let lastSampleTs: number;
-  if (sourceMs !== undefined) {
-    if (clock.sourceBaseMs === undefined || clock.hostBaseMs === undefined) {
-      clock.sourceBaseMs = sourceMs;
-      clock.hostBaseMs = latestAllowed;
-    }
-    const sourceDeltaMs = (sourceMs - clock.sourceBaseMs) >>> 0;
-    if (clock.lastSourceDeltaMs !== undefined && sourceDeltaMs <= clock.lastSourceDeltaMs) {
-      return {signals, mask, ts: clock.lastTs};
-    }
-    lastSampleTs = clock.hostBaseMs + sourceDeltaMs;
-    if (lastSampleTs > latestAllowed) {
-      clock.hostBaseMs -= lastSampleTs - latestAllowed;
-      lastSampleTs = latestAllowed;
-    }
-    clock.lastSourceDeltaMs = sourceDeltaMs;
-    clock.lastSequence = sequence;
-  } else {
-    // Legacy packets have no source clock. Drop compressed bursts instead of
-    // manufacturing future timestamps from arrival time.
-    lastSampleTs = clock.lastTs ? Math.min(clock.lastTs + signalLen * ts, latestAllowed) : latestAllowed;
-    if (clock.lastTs && lastSampleTs <= clock.lastTs) {
-      return {signals, mask, ts: clock.lastTs};
-    }
-  }
-
-  let refDate = lastSampleTs - (signalLen - 1) * ts;
   for (let i = 0; i < signalLen; i++) {
     mask.push([refDate, data.getUint16(offset, true)]);
     offset += 2;
@@ -121,9 +52,8 @@ export function dataViewToSignalData(data: DataView, numChs: number, fs: number,
     }
     signals.push(row);
     refDate += ts;
-  }
-  clock.lastTs = lastSampleTs;
-  return {signals, mask, ts: lastSampleTs};
+  };
+  return {signals, mask, ts: refDate};
 }
 
 export function dataViewToMetrics(data: DataView): number[] {

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -17,17 +17,86 @@ function getDataByteLength(dtype: string): number {
   return 0;
 }
 
-export function dataViewToSignalData(data: DataView, numChs: number, fs: number, dtype: string, lastTs: number): {signals: number[][], mask: number[][], ts: number} {
+const TIMED_SIGNAL_MAGIC0 = 0x54;
+const TIMED_SIGNAL_MAGIC1 = 0x53;
+const TIMED_SIGNAL_VERSION = 1;
+const TIMED_SIGNAL_HEADER_LEN = 12;
+const STREAM_PLAYOUT_DELAY_MS = 500;
+
+export interface SignalClock {
+  lastTs: number;
+  sourceBaseMs?: number;
+  hostBaseMs?: number;
+  lastSourceDeltaMs?: number;
+  lastSequence?: number;
+}
+
+export function createSignalClock(): SignalClock {
+  return { lastTs: 0 };
+}
+
+export function dataViewToSignalData(data: DataView, numChs: number, fs: number, dtype: string, clock: SignalClock): {signals: number[][], mask: number[][], ts: number} {
   const ts = 1000/fs;
   const byteLen = getDataByteLength(dtype);
-  const signalLen = data.getUint16(0, true) / (numChs * byteLen + 2);
+  const stride = numChs * byteLen + 2;
+  const packetLen = data.getUint16(0, true);
+  let signalBytes = packetLen;
+  let offset = 2;
+  let sourceMs: number|undefined;
+  let sequence: number|undefined;
+
+  if (packetLen >= TIMED_SIGNAL_HEADER_LEN &&
+      data.byteLength >= 2 + TIMED_SIGNAL_HEADER_LEN &&
+      data.getUint8(2) === TIMED_SIGNAL_MAGIC0 &&
+      data.getUint8(3) === TIMED_SIGNAL_MAGIC1 &&
+      data.getUint8(4) === TIMED_SIGNAL_VERSION) {
+    sourceMs = data.getUint32(6, true);
+    sequence = data.getUint16(10, true);
+    signalBytes = data.getUint16(12, true);
+    offset += TIMED_SIGNAL_HEADER_LEN;
+    if (signalBytes + TIMED_SIGNAL_HEADER_LEN > packetLen) {
+      throw new Error('Timed signal payload length exceeds packet length');
+    }
+  }
+  if (stride === 0 || signalBytes % stride !== 0) {
+    throw new Error('Invalid signal payload length');
+  }
+  const signalLen = signalBytes / stride;
   const signals: number[][] = [];
   const mask: number[][] = [];
-  let offset = 2;
-  let refDate = Date.now() - ts*signalLen;
-  if (refDate < lastTs) {
-    refDate = lastTs;
+  if (!signalLen) {
+    return {signals, mask, ts: clock.lastTs};
   }
+
+  const now = Date.now();
+  const latestAllowed = now - STREAM_PLAYOUT_DELAY_MS;
+  let lastSampleTs: number;
+  if (sourceMs !== undefined) {
+    if (clock.sourceBaseMs === undefined || clock.hostBaseMs === undefined) {
+      clock.sourceBaseMs = sourceMs;
+      clock.hostBaseMs = latestAllowed;
+    }
+    const sourceDeltaMs = (sourceMs - clock.sourceBaseMs) >>> 0;
+    if (clock.lastSourceDeltaMs !== undefined && sourceDeltaMs <= clock.lastSourceDeltaMs) {
+      return {signals, mask, ts: clock.lastTs};
+    }
+    lastSampleTs = clock.hostBaseMs + sourceDeltaMs;
+    if (lastSampleTs > latestAllowed) {
+      clock.hostBaseMs -= lastSampleTs - latestAllowed;
+      lastSampleTs = latestAllowed;
+    }
+    clock.lastSourceDeltaMs = sourceDeltaMs;
+    clock.lastSequence = sequence;
+  } else {
+    // Legacy packets have no source clock. Drop compressed bursts instead of
+    // manufacturing future timestamps from arrival time.
+    lastSampleTs = clock.lastTs ? Math.min(clock.lastTs + signalLen * ts, latestAllowed) : latestAllowed;
+    if (clock.lastTs && lastSampleTs <= clock.lastTs) {
+      return {signals, mask, ts: clock.lastTs};
+    }
+  }
+
+  let refDate = lastSampleTs - (signalLen - 1) * ts;
   for (let i = 0; i < signalLen; i++) {
     mask.push([refDate, data.getUint16(offset, true)]);
     offset += 2;
@@ -52,8 +121,9 @@ export function dataViewToSignalData(data: DataView, numChs: number, fs: number,
     }
     signals.push(row);
     refDate += ts;
-  };
-  return {signals, mask, ts: refDate};
+  }
+  clock.lastTs = lastSampleTs;
+  return {signals, mask, ts: lastSampleTs};
 }
 
 export function dataViewToMetrics(data: DataView): number[] {

--- a/src/components/Tiles/IoTile.tsx
+++ b/src/components/Tiles/IoTile.tsx
@@ -91,7 +91,7 @@ const UioTile = observer(({ config, uioState, dashboard, pause }: TileProps) => 
             info={info}
             state={state}
             onChange={onChange}
-            disabled={!!pause}
+            disabled={!!pause || !uioState?.hydrated}
           />
         </Stack>
       </GridZStack>

--- a/src/components/Tiles/UioTile.tsx
+++ b/src/components/Tiles/UioTile.tsx
@@ -132,7 +132,7 @@ const UioTile = observer(({ config, uioState, dashboard, pause, size }: TileProp
                     info={info}
                     state={state}
                     onChange={(state: number) => onChange(io, state)}
-                    disabled={!!pause}
+                    disabled={!!pause || !uioState?.hydrated}
                   />
                 </Grid>
               );

--- a/src/components/UioBarItem/UioDialog.tsx
+++ b/src/components/UioBarItem/UioDialog.tsx
@@ -121,7 +121,7 @@ const UioDialog = ({ open, onClose, dashboard, device }: Props) => {
                     index={idx}
                     config={io.config}
                     io={io.state}
-                    disabled={!device.state.connected}
+                    disabled={!device.state.connected || !device.uioState.hydrated}
                     onChange={async (state: number) => {
                       await device.uioState.updateIoState(idx, state);
                     }}

--- a/src/models/device.tsx
+++ b/src/models/device.tsx
@@ -187,6 +187,7 @@ const Device = types
 .actions(self => ({
   onDisconnected: function(id: string) {
     self.state.setConnectionState(DeviceConnectionType.DISCONNECTED);
+    self.uioState.reset();
     new Promise<void>(async (resolve) => {
       await self.setNotifications(false);
       await self.stopPolling();
@@ -201,10 +202,12 @@ const Device = types
     try {
       self.dashboard = dashboard;
       self.slots.forEach(slot => slot.clear());
+      self.uioState.reset();
       self.state.setConnectionState(DeviceConnectionType.CONNECTING);
       yield ApiManager.deviceConnect(self.id, self.dashboard.device.slots, self.onDisconnected);
       self.state.setConnectionState(DeviceConnectionType.CONNECTED);
       yield self.setNotifications(true);
+      yield self.fetchUioState();
       yield self.startPolling();
     } catch (error) {
       console.error(error);
@@ -225,6 +228,7 @@ const Device = types
         yield self.stopRecording();
         yield ApiManager.deviceDisconnect(self.id);
         self.state.setConnectionState(DeviceConnectionType.DISCONNECTED);
+        self.uioState.reset();
       }
     } catch (error) {
       console.error(`Failed disconnecting from ${self.shortId}. (${error})`);

--- a/src/models/uioState.ts
+++ b/src/models/uioState.ts
@@ -261,6 +261,7 @@ export const UioState = types
     io5: types.optional(types.number, 0),
     io6: types.optional(types.number, 0),
     io7: types.optional(types.number, 0),
+    hydrated: types.optional(types.boolean, false),
   })
   .views(self => ({
     get state(): number[] {
@@ -290,6 +291,10 @@ export const UioState = types
       self.io5 = state[5];
       self.io6 = state[6];
       self.io7 = state[7];
+      self.hydrated = true;
+    },
+    reset() {
+      self.hydrated = false;
     },
   }))
   .actions(self => ({
@@ -313,22 +318,13 @@ export const UioState = types
   }))
   .actions(self => ({
     updateState: flow(function* (state: number[]) {
-      if (state.length !== 8) {
-        console.debug(`Invalid state length: ${state.length}`);
-        return;
-      }
-      self.io0 = state[0];
-      self.io1 = state[1];
-      self.io2 = state[2];
-      self.io3 = state[3];
-      self.io4 = state[4];
-      self.io5 = state[5];
-      self.io6 = state[6];
-      self.io7 = state[7];
-      // self._pushState();
+      self._setState(state);
     }),
     updateIoState: flow(function* (index: number, state: number) {
       let didChange = false;
+      if (!self.hydrated) {
+        return;
+      }
       if (index < 0 || index > 7) {
         console.debug(`Invalid index: ${index}`);
         return;


### PR DESCRIPTION
## Summary
- Request the device UIO payload explicitly after USB notifications are registered.
- Resolve the request from the next valid eight-byte UIO packet, with timeout and disconnect handling.
- Keep UIO controls disabled until a valid device state hydrates the model.

## Validation
- `npm run build`