### PR TITLE
fix: report latest signal quality

### DIFF
--- a/src/models/slot.ts
+++ b/src/models/slot.ts
@@ -323,7 +323,9 @@ export const SlotMask = types
     return amounts;
   },
   get qosState(): number {
-    return Math.round(self.qos.reduce((a, b) => a + b, 0) / self.qos.length);
+    // The header badge represents current signal quality. Averaging the
+    // retained plot history made it lag behind a recovered PPG signal.
+    return self.qos.length ? self.qos[self.qos.length - 1] : 0;
   }
 
 })).actions(self => ({


### PR DESCRIPTION
Makes the signal-quality badge report the latest mask state instead of averaging the retained plot history.

This prevents a recovered PPG signal from remaining FAIR after the firmware reports GOOD.